### PR TITLE
Accessibility

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "chaild-site",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -28,3 +28,23 @@
 .subTitle {
   color: $subTitle;
 }
+
+/* !important needed to out-rank the '.subTitle { ... !important }'
+   light-theme rules in Greeting.scss and Footer.scss */
+.dark-mode.subTitle {
+  color: $subTitleDark !important;
+}
+
+/* keyboard focus indicators, both themes */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid $buttonColor;
+  outline-offset: 2px;
+}
+
+.dark-mode a:focus-visible,
+.dark-mode button:focus-visible,
+.dark-mode input:focus-visible {
+  outline-color: $accentColorDark;
+}

--- a/src/_globalColor.scss
+++ b/src/_globalColor.scss
@@ -10,17 +10,19 @@ $topButtonHover: #000;
 // text colors light theme
 $titleColor: #000000;
 $textColor: #000000;
-$subTitle: #868e96;
+$subTitle: #6c757d; // 4.7:1 on white (WCAG AA)
 $cardSubtitle: #666666;
 $talkCardSubTitle: #7f8287;
 $blogCardTitleColor: #262626;
 
 // text color dark theme
 $textColorDark: #ffffff;
+$subTitleDark: #a9b1ba; // secondary text on $darkBackground, 7.9:1
+$accentColorDark: #c4a7f5; // links/accents on $darkBackground, 8.3:1
 
 // toggle switch colors
 $toggleCheck: #2196f3;
-$toggleSwitchSliderBG: #ccc;
+$toggleSwitchSliderBG: #767676; // >=3:1 against the white thumb and page
 
 // light background colors
 $lightBackground1: #fff;

--- a/src/components/ToggleSwitch/ToggleSwitch.js
+++ b/src/components/ToggleSwitch/ToggleSwitch.js
@@ -1,25 +1,23 @@
-import React, {useState, useContext} from "react";
+import React, {useContext} from "react";
 import emoji from "react-easy-emoji";
 import StyleContext from "../../contexts/StyleContext";
 import "./ToggleSwitch.scss";
 
 const ToggleSwitch = () => {
-  const {isDark} = useContext(StyleContext);
-  const [isChecked, setChecked] = useState(isDark);
-  const styleContext = useContext(StyleContext);
+  const {isDark, changeTheme} = useContext(StyleContext);
 
   return (
     <label className="switch">
       <input
         type="checkbox"
         checked={isDark}
-        onChange={() => {
-          styleContext.changeTheme();
-          setChecked(!isChecked);
-        }}
+        onChange={changeTheme}
+        aria-label="Switch between dark and light mode"
       />
       <span className="slider round">
-        <span className="emoji">{isChecked ? emoji("🌜") : emoji("☀️")}</span>
+        <span className="emoji" aria-hidden="true">
+          {isDark ? emoji("🌜") : emoji("☀️")}
+        </span>
       </span>
     </label>
   );

--- a/src/components/ToggleSwitch/ToggleSwitch.scss
+++ b/src/components/ToggleSwitch/ToggleSwitch.scss
@@ -7,9 +7,14 @@
   height: 26px;
 }
 
-/* Fix visible slider checkbox */
-input {
-  transform: scale(0.5);
+/* Visually hide the checkbox; the slider is the visual control */
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
 }
 
 .slider {
@@ -40,8 +45,9 @@ input:checked + .slider {
   background-color: $toggleCheck;
 }
 
-input:focus + .slider {
-  box-shadow: $toggleCheck;
+input:focus-visible + .slider {
+  outline: 3px solid $toggleCheck;
+  outline-offset: 2px;
 }
 
 input:checked + .slider::before,

--- a/src/components/blogCard/BlogCard.js
+++ b/src/components/blogCard/BlogCard.js
@@ -2,29 +2,18 @@ import React from "react";
 import "./BlogCard.scss";
 
 export default function BlogCard({blog, isDark}) {
-  function handleClick() {
-    if (!blog.url) {
-      console.log(`URL for ${blog.title} not found`);
-      return;
-    }
-    // Check if it's an internal link
-    if (blog.url.startsWith("/")) {
-      window.location.href = blog.url;
-    } else {
-      // External link
-      var win = window.open(blog.url, "_blank");
-      win.focus();
-    }
-  }
+  const isExternal = Boolean(blog.url) && !blog.url.startsWith("/");
 
   return (
-    <div onClick={handleClick}>
+    <div>
       <div className={isDark ? "blog-container dark-mode" : "blog-container"}>
         <a
           className={
             isDark ? "dark-mode blog-card blog-card-shadow" : "blog-card"
           }
-          href="#blog"
+          href={blog.url}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noreferrer" : undefined}
         >
           <h3 className={isDark ? "small-dark blog-title" : "blog-title"}>
             {blog.title}

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -1,10 +1,16 @@
 import React from "react";
 import "./Button.scss";
 
-export default function Button({text, className, href, newTab}) {
+export default function Button({text, className, href, newTab, download}) {
   return (
     <div className={className}>
-      <a className="main-button" href={href} target={newTab && "_blank"}>
+      <a
+        className="main-button"
+        href={href}
+        target={newTab ? "_blank" : undefined}
+        rel={newTab ? "noreferrer" : undefined}
+        download={download}
+      >
         {text}
       </a>
     </div>

--- a/src/components/footer/Footer.scss
+++ b/src/components/footer/Footer.scss
@@ -5,7 +5,9 @@
   color: $subTitle !important;
 }
 
-.dark-mode {
+/* scoped to the footer; a bare .dark-mode selector here used to leak
+   'color: white !important' onto every dark-mode element site-wide */
+.dark-mode.footer-text {
   color: $textColorDark !important;
 }
 

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,4 +1,4 @@
-import React, {useContext} from "react";
+import React, {useContext, useState} from "react";
 import Headroom from "react-headroom";
 import "./Header.scss";
 import ToggleSwitch from "../ToggleSwitch/ToggleSwitch";
@@ -12,61 +12,82 @@ import {
 
 function Header() {
   const {isDark} = useContext(StyleContext);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const viewSkills = skillsSection.display;
   const viewPeople = peopleSection.display;
   const viewBlog = blogSection.display;
-  
+
   // Detect if we're on a blog page
   const isOnBlogPage = window.location.pathname.startsWith("/blog");
-  
+
   // Helper to create correct link based on current page.
   // Use full origin when on a different page so anchors work with custom domains.
-  const getLink = (anchor) => {
+  const getLink = anchor => {
     if (isOnBlogPage) {
       return `${window.location.origin}/#${anchor}`;
     }
     return `#${anchor}`;
   };
 
+  const closeMenu = () => setIsMenuOpen(false);
+
+  const menuClasses = [
+    "menu",
+    isDark ? "dark-menu" : "",
+    isMenuOpen ? "menu-open" : ""
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <Headroom>
       <header className={isDark ? "dark-menu header" : "header"}>
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
         <a href="/" className="logo">
           <span className="grey-color"> &lt;</span>
           <span className="logo-name">{greeting.username}</span>
           <span className="grey-color">/&gt;</span>
         </a>
-        <input className="menu-btn" type="checkbox" id="menu-btn" />
-        <label
+        <button
+          type="button"
           className="menu-icon"
-          htmlFor="menu-btn"
-          style={{color: "white"}}
+          aria-expanded={isMenuOpen}
+          aria-controls="nav-menu"
+          aria-label="Menu"
+          onClick={() => setIsMenuOpen(open => !open)}
         >
           <span className={isDark ? "navicon navicon-dark" : "navicon"}></span>
-        </label>
-        <ul className={isDark ? "dark-menu menu" : "menu"}>
-          {viewSkills && (
-            <li>
-              <a href={getLink("skills")}>Our mission</a>
-            </li>
-          )}
-          {viewPeople && (
-            <li>
-              <a href={getLink("people")}>Our people</a>
-            </li>
-          )}
-          {viewBlog && (
-            <li>
-              <a href="/blog">News</a>
-            </li>
-          )}
-          <li>
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <a>
+        </button>
+        <nav aria-label="Main">
+          <ul id="nav-menu" className={menuClasses}>
+            {viewSkills && (
+              <li>
+                <a href={getLink("skills")} onClick={closeMenu}>
+                  Our mission
+                </a>
+              </li>
+            )}
+            {viewPeople && (
+              <li>
+                <a href={getLink("people")} onClick={closeMenu}>
+                  Our people
+                </a>
+              </li>
+            )}
+            {viewBlog && (
+              <li>
+                <a href="/blog" onClick={closeMenu}>
+                  News
+                </a>
+              </li>
+            )}
+            <li className="switch-item">
               <ToggleSwitch />
-            </a>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </nav>
       </header>
     </Headroom>
   );

--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -46,8 +46,43 @@
 }
 
 .header li a:hover,
-.header .menu-btn:hover {
+.header .menu-icon:hover {
   background-color: $headerHoverBG;
+}
+
+.header li.switch-item {
+  display: block;
+  padding: 15px 20px;
+}
+
+/* skip link: hidden above the viewport until focused */
+.skip-link {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  padding: 12px 18px;
+  background-color: $buttonColor;
+  color: $textColorDark;
+  text-decoration: none;
+  border-radius: 4px;
+  transform: translateY(-250%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+/* keyboard focus indicators */
+.header a:focus-visible,
+.header .menu-icon:focus-visible {
+  outline: 3px solid $buttonColor;
+  outline-offset: 2px;
+}
+
+.dark-menu a:focus-visible,
+.dark-menu .menu-icon:focus-visible {
+  outline-color: $textColorDark;
 }
 
 .header .logo {
@@ -85,6 +120,8 @@
   padding: 28px 20px;
   position: relative;
   user-select: none;
+  background: transparent;
+  border: none;
 }
 
 .header .menu-icon .navicon {
@@ -130,30 +167,26 @@
   top: -5px;
 }
 
-/* menu btn */
+/* open menu state (aria-expanded is set by the menu button in Header.js) */
 
-.header .menu-btn {
-  display: none;
-}
-
-.header .menu-btn:checked ~ .menu {
+.header .menu.menu-open {
   max-height: 486px;
 }
 
-.header .menu-btn:checked ~ .menu-icon .navicon {
+.header .menu-icon[aria-expanded="true"] .navicon {
   background: transparent !important;
 }
 
-.header .menu-btn:checked ~ .menu-icon .navicon:before {
+.header .menu-icon[aria-expanded="true"] .navicon:before {
   transform: rotate(-45deg);
 }
 
-.header .menu-btn:checked ~ .menu-icon .navicon:after {
+.header .menu-icon[aria-expanded="true"] .navicon:after {
   transform: rotate(45deg);
 }
 
-.header .menu-btn:checked ~ .menu-icon:not(.steps) .navicon:before,
-.header .menu-btn:checked ~ .menu-icon:not(.steps) .navicon:after {
+.header .menu-icon[aria-expanded="true"] .navicon:before,
+.header .menu-icon[aria-expanded="true"] .navicon:after {
   top: 0;
 }
 

--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -38,6 +38,10 @@
   color: $subTitle;
 }
 
+.dark-menu .grey-color {
+  color: $subTitleDark;
+}
+
 .header li a {
   display: block;
   padding: 15px 20px;

--- a/src/components/softwareSkills/SoftwareSkill.js
+++ b/src/components/softwareSkills/SoftwareSkill.js
@@ -3,6 +3,9 @@ import "./SoftwareSkill.scss";
 import {skillsSection} from "../../portfolio";
 
 export default function SoftwareSkill() {
+  if (!skillsSection.softwareSkills.length) {
+    return null;
+  }
   return (
     <div>
       <div className="software-skills-main-div">

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -42,11 +42,12 @@ const Main = () => {
         ) : (
           <>
             <Header />
-            <Greeting />
-            <Blogs />
-            <Skills />
-            <People />
-
+            <main id="main-content">
+              <Greeting />
+              <Blogs />
+              <Skills />
+              <People />
+            </main>
             <ScrollToTopButton />
           </>
         )}

--- a/src/containers/blogs/Blogs.js
+++ b/src/containers/blogs/Blogs.js
@@ -27,9 +27,11 @@ export default function Blogs() {
 
   return (
     <Fade bottom duration={1000} distance="20px">
-      <div className="main" id="blogs">
+      <section className="main" id="blogs" aria-labelledby="blogs-heading">
         <div className="blog-header">
-          <h1 className="blog-header-text">{blogSection.title}</h1>
+          <h2 id="blogs-heading" className="blog-header-text">
+            {blogSection.title}
+          </h2>
           <p
             className={
               isDark ? "dark-mode blog-subtitle" : "subTitle blog-subtitle"
@@ -65,7 +67,7 @@ export default function Blogs() {
             />
           </div>
         </div>
-      </div>
+      </section>
     </Fade>
   );
 }

--- a/src/containers/greeting/Greeting.js
+++ b/src/containers/greeting/Greeting.js
@@ -15,11 +15,12 @@ export default function Greeting() {
   }
   return (
     <Fade bottom duration={1000} distance="40px">
-      <div className="greet-main" id="greeting">
+      <section className="greet-main" id="greeting" aria-labelledby="greeting-heading">
         <div className="greeting-main">
           <div className="greeting-text-div">
             <div>
               <h1
+                id="greeting-heading"
                 className={isDark ? "dark-mode greeting-text" : "greeting-text"}
               >
                 {" "}
@@ -36,31 +37,29 @@ export default function Greeting() {
                 {greeting.subTitle}
               </p>
               <div className="button-greeting-div">
-                
                 {greeting.resumeLink && (
-                  <a
+                  <Button
+                    text="Download our white paper"
                     href="/static/media/CHAILD-white-paper-1.pdf"
                     download="CHAILD-white-paper-1.pdf"
                     className="download-link-button"
-                  >
-                    <Button text="Download our white paper" />
-                  </a>
+                  />
                 )}
-              </div>              
+              </div>
             </div>
           </div>
-          <div className="greeting-image-div">
+          <div className="greeting-image-div" aria-hidden="true">
             {illustration.animated ? (
               <DisplayLottie animationData={landingPerson} />
             ) : (
               <img
-                alt="man sitting on table"
+                alt=""
                 src={require("../../assets/images/manOnTable.svg")}
               ></img>
             )}
           </div>
         </div>
-      </div>
+      </section>
     </Fade>
   );
 }

--- a/src/containers/people/People.js
+++ b/src/containers/people/People.js
@@ -1,10 +1,8 @@
 import React, {useContext} from "react";
 import "./People.scss";
-// import SoftwareSkill from "../../components/softwareSkills/SoftwareSkill";
-import {illustration, peopleSection} from "../../portfolio";
+import emoji from "react-easy-emoji";
+import {peopleSection} from "../../portfolio";
 import {Fade} from "react-reveal";
-import codingPerson from "../../assets/lottie/codingPerson";
-import DisplayLottie from "../../components/displayLottie/DisplayLottie";
 import StyleContext from "../../contexts/StyleContext";
 
 export default function People() {
@@ -12,16 +10,51 @@ export default function People() {
   if (!peopleSection.display) {
     return null;
   }
+
+  const renderGroup = group => (
+    <div key={group.title}>
+      <h3
+        className={
+          isDark
+            ? "dark-mode subTitle people-text people-group-title"
+            : "subTitle people-text people-group-title"
+        }
+      >
+        {group.title}
+      </h3>
+      <ul className="people-list">
+        {group.members.map((member, i) => (
+          <li
+            key={i}
+            className={
+              isDark ? "dark-mode subTitle people-text" : "subTitle people-text"
+            }
+          >
+            <span aria-hidden="true">{emoji("⚡ ")}</span>
+            {member}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  const [firstGroup, ...otherGroups] = peopleSection.peopleGroups;
+
   return (
-    <div className={isDark ? "dark-mode main" : "main"} id="people">
+    <section
+      className={isDark ? "dark-mode main" : "main"}
+      id="people"
+      aria-labelledby="people-heading"
+    >
       <div className="people-main-div">
         <Fade left duration={1000}>
           <div className="people-text-div">
-            <h1
+            <h2
+              id="people-heading"
               className={isDark ? "dark-mode people-heading" : "people-heading"}
             >
               {peopleSection.title}{" "}
-            </h1>
+            </h2>
             <p
               className={
                 isDark
@@ -31,44 +64,15 @@ export default function People() {
             >
               {peopleSection.subTitle}
             </p>
-            {/* <SoftwareSkill /> */}
             <div className="people-text-row-div">
               <div className="people-text-col-div">
-                {peopleSection.people1.map((people1, i) => {
-                  return (
-                    <p
-                      key={i}
-                      className={
-                        isDark
-                          ? "dark-mode subTitle people-text"
-                          : "subTitle people-text"
-                      }
-                    >
-                      {people1}
-                    </p>
-                  );
-                })}
+                {renderGroup(firstGroup)}
               </div>
-              <div>
-                {peopleSection.people2.map((people2, i) => {
-                  return (
-                    <p
-                      key={i}
-                      className={
-                        isDark
-                          ? "dark-mode subTitle people-text"
-                          : "subTitle people-text"
-                      }
-                    >
-                      {people2}
-                    </p>
-                  );
-                })}
-              </div>
+              <div>{otherGroups.map(renderGroup)}</div>
             </div>
           </div>
         </Fade>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/containers/people/People.scss
+++ b/src/containers/people/People.scss
@@ -24,6 +24,20 @@
   font-size: 56px;
   font-weight: 400;
 }
+
+.people-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.people-list li {
+  margin: 16px 0;
+}
+
+.people-group-title {
+  font-size: 1em;
+  margin: 16px 0 8px;
+}
 .subTitle {
   color: $subTitle;
 }

--- a/src/containers/skills/Skills.js
+++ b/src/containers/skills/Skills.js
@@ -1,5 +1,6 @@
 import React, {useContext} from "react";
 import "./Skills.scss";
+import emoji from "react-easy-emoji";
 import SoftwareSkill from "../../components/softwareSkills/SoftwareSkill";
 import {illustration, skillsSection} from "../../portfolio";
 import {Fade} from "react-reveal";
@@ -13,15 +14,19 @@ export default function Skills() {
     return null;
   }
   return (
-    <div className={isDark ? "dark-mode main" : "main"} id="skills">
+    <section
+      className={isDark ? "dark-mode main" : "main"}
+      id="skills"
+      aria-labelledby="skills-heading"
+    >
       <div className="skills-main-div">
         <Fade left duration={1000}>
-          <div className="skills-image-div">
+          <div className="skills-image-div" aria-hidden="true">
             {illustration.animated ? (
               <DisplayLottie animationData={codingPerson} />
             ) : (
               <img
-                alt="Man Working"
+                alt=""
                 src={require("../../assets/lottie/splashAnimation")}
               ></img>
             )}
@@ -29,11 +34,12 @@ export default function Skills() {
         </Fade>
         <Fade right duration={1000}>
           <div className="skills-text-div">
-            <h1
+            <h2
+              id="skills-heading"
               className={isDark ? "dark-mode skills-heading" : "skills-heading"}
             >
               {skillsSection.title}{" "}
-            </h1>
+            </h2>
             <p
               className={
                 isDark
@@ -44,10 +50,10 @@ export default function Skills() {
               {skillsSection.subTitle}
             </p>
             <SoftwareSkill />
-            <div>
-              {skillsSection.skills.map((skills, i) => {
+            <ul className="skills-list">
+              {skillsSection.skills.map((skill, i) => {
                 return (
-                  <p
+                  <li
                     key={i}
                     className={
                       isDark
@@ -55,14 +61,15 @@ export default function Skills() {
                         : "subTitle skills-text"
                     }
                   >
-                    {skills}
-                  </p>
+                    <span aria-hidden="true">{emoji("⚡ ")}</span>
+                    {skill}
+                  </li>
                 );
               })}
-            </div>
+            </ul>
           </div>
         </Fade>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/containers/skills/Skills.scss
+++ b/src/containers/skills/Skills.scss
@@ -24,6 +24,15 @@
   font-size: 56px;
   font-weight: 400;
 }
+
+.skills-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.skills-list li {
+  margin: 16px 0;
+}
 .subTitle {
   color: $subTitle;
 }

--- a/src/containers/topbutton/Top.js
+++ b/src/containers/topbutton/Top.js
@@ -25,7 +25,12 @@ export default function Top() {
   }; //To make sure that this button is not visible at starting.
   // When the user clicks on the button, scroll to the top of the document
   return (
-    <button onClick={TopEvent} id="topButton" title="Go to top">
+    <button
+      onClick={TopEvent}
+      id="topButton"
+      title="Go to top"
+      aria-label="Scroll to top"
+    >
       <i className="fas fa-hand-point-up" aria-hidden="true"></i>
     </button>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
 @font-face {
   font-family: "Montserrat";
   src: local("Montserrat"),
-    url("./assets/fonts/Montserrat-Regular.ttf") format("woff");
+    url("./assets/fonts/Montserrat-Regular.ttf") format("truetype");
   font-display: swap;
 }
 code {
@@ -30,7 +30,6 @@ body {
 @media (max-width: 1380px) {
   html,
   body {
-    font-size: rem;
     line-height: normal;
   }
 }

--- a/src/pages/BlogList.jsx
+++ b/src/pages/BlogList.jsx
@@ -18,6 +18,10 @@ export default function BlogList() {
   const [allTags, setAllTags] = useState([]);
 
   useEffect(() => {
+    document.title = "News | CHAILD";
+  }, []);
+
+  useEffect(() => {
     // Fetch all blog metadata from markdown files
     async function loadBlogs() {
       const blogData = await fetchAllBlogMetadata(blogSection.blogSlugs);
@@ -59,7 +63,7 @@ export default function BlogList() {
       <StyleProvider value={{ isDark: isDark, changeTheme: changeTheme }}>
         <Header />
         <Fade bottom duration={1000} distance="20px">
-          <div className="main" id="blogs">
+          <main id="main-content" className="main">
             <div className="blog-header">
               <h1 className="blog-header-text">{blogSection.title}</h1>
               <p className={isDark ? "dark-mode blog-subtitle" : "subTitle blog-subtitle"}>
@@ -78,6 +82,7 @@ export default function BlogList() {
                       className={`tag-button ${
                         selectedTags.includes(tag) ? "active" : ""
                       } ${isDark ? "dark-mode" : ""}`}
+                      aria-pressed={selectedTags.includes(tag)}
                       onClick={() => toggleTag(tag)}
                     >
                       {tag}
@@ -109,7 +114,7 @@ export default function BlogList() {
                 )}
               </div>
             </div>
-          </div>
+          </main>
         </Fade>
         <ScrollToTopButton />
       </StyleProvider>

--- a/src/pages/BlogList.scss
+++ b/src/pages/BlogList.scss
@@ -45,22 +45,23 @@
 
   &:hover {
     background-color: $buttonColor;
-    color: white;
+    color: $textColorDark;
   }
 
   &.active {
     background-color: $buttonColor;
-    color: white;
+    color: $textColorDark;
   }
 }
 
 .tag-button.dark-mode {
-  border-color: $buttonColor;
-  color: $buttonColor;
+  border-color: $accentColorDark;
+  color: $accentColorDark;
 
   &:hover,
   &.active {
     background-color: $buttonColor;
-    color: white;
+    border-color: $buttonColor;
+    color: $textColorDark;
   }
 }

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -46,6 +46,12 @@ export default function BlogPost({ slug }) {
     loadRenderer();
   }, [slug]);
 
+  useEffect(() => {
+    if (post && post.title) {
+      document.title = `${post.title} | CHAILD`;
+    }
+  }, [post]);
+
   const changeTheme = () => {
     setIsDark(!isDark);
   };
@@ -55,9 +61,9 @@ export default function BlogPost({ slug }) {
       <div className={isDark ? "dark-mode" : null}>
         <StyleProvider value={{ isDark: isDark, changeTheme: changeTheme }}>
           <Header />
-          <div className="blog-post-container">
+          <main id="main-content" className="blog-post-container">
             <p>Loading...</p>
-          </div>
+          </main>
           <ScrollToTopButton />
         </StyleProvider>
       </div>
@@ -69,10 +75,10 @@ export default function BlogPost({ slug }) {
       <div className={isDark ? "dark-mode" : null}>
         <StyleProvider value={{ isDark: isDark, changeTheme: changeTheme }}>
           <Header />
-          <div className="blog-post-container">
+          <main id="main-content" className="blog-post-container">
             <h1>Post not found</h1>
             <a href="/blog">← Back to all posts</a>
-          </div>
+          </main>
           <ScrollToTopButton />
         </StyleProvider>
       </div>
@@ -84,7 +90,7 @@ export default function BlogPost({ slug }) {
       <StyleProvider value={{ isDark: isDark, changeTheme: changeTheme }}>
         <Header />
         <Fade bottom duration={1000} distance="20px">
-          <div className="blog-post-container">
+          <main id="main-content" className="blog-post-container">
             <a href="/blog" className="back-link">
               ← Back to all posts
             </a>
@@ -106,10 +112,16 @@ export default function BlogPost({ slug }) {
               </div>
             )}
 
-            {/* Display date */}
+            {/* Display date; format in UTC so "2026-02-01" doesn't render
+                as the previous day in timezones west of UTC */}
             {post.date && (
               <p className={`blog-post-date ${isDark ? "dark-mode" : ""}`}>
-                Published: {new Date(post.date).toLocaleDateString()}
+                Published:{" "}
+                <time dateTime={post.date}>
+                  {new Date(post.date).toLocaleDateString(undefined, {
+                    timeZone: "UTC"
+                  })}
+                </time>
               </p>
             )}
 
@@ -130,7 +142,7 @@ export default function BlogPost({ slug }) {
                 Original / Download
               </a>
             )}
-          </div>
+          </main>
         </Fade>
         <ScrollToTopButton />
       </StyleProvider>

--- a/src/pages/BlogPost.scss
+++ b/src/pages/BlogPost.scss
@@ -15,6 +15,10 @@
   background-color: $darkBackground;
 }
 
+.dark-mode .back-link {
+  color: $accentColorDark;
+}
+
 .back-link {
   display: inline-block;
   color: $buttonColor;
@@ -60,7 +64,7 @@
 .read-more-link {
   display: inline-block;
   background-color: $buttonColor;
-  color: white;
+  color: $textColorDark;
   padding: 12px 24px;
   border-radius: 5px;
   text-decoration: none;
@@ -95,7 +99,7 @@
 
 .blog-tag.dark-mode {
   background-color: rgba($buttonColor, 0.2);
-  color: $buttonHover;
+  color: $accentColorDark;
 }
 
 .blog-post-date {
@@ -106,7 +110,7 @@
 }
 
 .dark-mode .blog-post-date {
-  color: #aaa;
+  color: $subTitleDark;
 }
 
 .blog-markdown {
@@ -153,11 +157,7 @@
 
   a {
     color: $buttonColor;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
+    text-decoration: underline;
   }
 }
 
@@ -170,6 +170,10 @@
 
 .dark-mode .blog-markdown {
   color: $textColorDark;
+
+  a {
+    color: $accentColorDark;
+  }
 
   code {
     background-color: rgba(255, 255, 255, 0.1);

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -36,19 +36,11 @@ const skillsSection = {
   title: "What we do",
   subTitle: "Our missions",
   skills: [
-    emoji(
-      "⚡ Defining children’s critical agency in the digital context"
-    ),
-    emoji("⚡ Establishing approaches to assess the impact on agency"),
-    emoji(
-      "⚡ Developing design principles for agency"
-    ),
-    emoji(
-      "⚡ Creating new guidelines for parental and educational support"
-    ),
-    emoji(
-      "⚡ Formulating policy recommendations to prioritise children’s agency"
-    )
+    "Defining children’s critical agency in the digital context",
+    "Establishing approaches to assess the impact on agency",
+    "Developing design principles for agency",
+    "Creating new guidelines for parental and educational support",
+    "Formulating policy recommendations to prioritise children’s agency"
   ],
 
   /* Make Sure to include correct Font Awesome Classname to view your icon
@@ -66,49 +58,36 @@ https://fontawesome.com/icons?d=gallery */
 const peopleSection = {
   title: "Who we are",
   subTitle: "A multidisciplinary team of researchers",
-  people1: [
-    "Co-investigators:",
-    emoji(
-      "⚡ Professor Sir Nigel Shadbolt, University of Oxford"
-    ),
-    emoji(
-      "⚡ Dr Jun Zhao, University of Oxford"
-    ),
-    emoji(
-      "⚡ Professor Manolis Mavrikis, University College London"
-    ),
-    emoji(
-      "⚡ Dr Carina Prunkl, University of Oxford"
-    ),
-    emoji(
-      "⚡ Professor Kaśka Porayska-Pomsta, University College London"
-    ),
-    emoji(
-      "⚡ Professor Wayne Holmes, University College London"
-    ),
-    emoji(
-      "⚡ Baroness Beeban Kidron, 5Rights Foundation"
-    ),
-
-  ],
-  people2: [
-    "Researchers:",
-    emoji(
-      "⚡ Dr Leslye Dias Duran, University of Oxford"
-    ),
-    emoji(
-      "⚡ Dr Vidminas Vizgirda, University College London and University of Oxford"
-    ),
-    emoji(
-      "⚡ Dr Isobel Voysey, University of Oxford"
-    ),
-    "Associated researchers:",
-    emoji(
-      "⚡ Dr Zaki Pauzi, University College London"
-    ),
-    emoji(
-      "⚡ Dr Sarah Turner, University College London"
-    ),
+  // Each group renders as a sub-heading with a list of members.
+  // The first group appears in the left column, the rest in the right.
+  peopleGroups: [
+    {
+      title: "Co-investigators:",
+      members: [
+        "Professor Sir Nigel Shadbolt, University of Oxford",
+        "Dr Jun Zhao, University of Oxford",
+        "Professor Manolis Mavrikis, University College London",
+        "Dr Carina Prunkl, University of Oxford",
+        "Professor Kaśka Porayska-Pomsta, University College London",
+        "Professor Wayne Holmes, University College London",
+        "Baroness Beeban Kidron, 5Rights Foundation"
+      ]
+    },
+    {
+      title: "Researchers:",
+      members: [
+        "Dr Leslye Dias Duran, University of Oxford",
+        "Dr Vidminas Vizgirda, University College London and University of Oxford",
+        "Dr Isobel Voysey, University of Oxford"
+      ]
+    },
+    {
+      title: "Associated researchers:",
+      members: [
+        "Dr Zaki Pauzi, University College London",
+        "Dr Sarah Turner, University College London"
+      ]
+    }
   ],
 
   /* Make Sure to include correct Font Awesome Classname to view your icon


### PR DESCRIPTION
Keyboard & screen-reader navigation

The mobile hamburger was a CSS-checkbox hack with a display:none input — unreachable by keyboard. Now a real <button> with aria-expanded/aria-controls; the menu closes after choosing a link.
Added a skip-to-content link, <nav>/<main> landmarks on every page, and site-wide :focus-visible outlines with a dark-theme variant.
The dark-mode toggle is labelled for screen readers; fixed a state desync bug, an invalid box-shadow that hid its focus ring, and a global input { transform: scale(0.5) } style leak.
Blog cards were mouse-only `<div onClick>`s around a bogus #blog anchor — keyboard users couldn't open posts. Now real links (also removes a popup-blocker crash).
Fixed the nested `<a>-inside-<a>` on the white-paper download button.


Semantic HTML & hierarchy

One `<h1>` per page; sections are `<section aria-labelledby>` with h2 titles; mission/team bullets are real `<ul>/<li>` (team data restructured into titled groups in portfolio.js); post dates use <time> formatted in UTC (fixes an off-by-one-day display west of UTC); per-page document.title.


Colour contrast, measured in both themes

Light: secondary text #868e96 was 3.3:1 on white → #6c757d (4.7:1).
Dark: tag buttons, back-link, and markdown links rendered purple on #171c28 at 1.5:1 → new $accentColorDark (8.3:1) / $subTitleDark (7.9:1). Root cause found: a bare .dark-mode { color: white !important } in Footer.scss leaked site-wide — now scoped.
Toggle track meets the 3:1 UI minimum; body links underlined; Montserrat font declared truetype (was mislabelled woff).


Verification: all checked live in the dev server in both themes (computed colours, landmarks, hamburger at mobile width, tag filter aria-pressed). npm run build passes. npm test fails identically on main (pre-existing enzyme/TextDecoder issue)